### PR TITLE
Safely access X-Sentry-Error header

### DIFF
--- a/SentryDotNet/SentryClient.cs
+++ b/SentryDotNet/SentryClient.cs
@@ -141,8 +141,11 @@ namespace SentryDotNet
 
             if (response.StatusCode != HttpStatusCode.OK)
             {
-                throw new SentryClientException(HttpStatusCode.BadRequest,
-                    string.Join(".", response.Headers.GetValues("X-Sentry-Error")));
+                var errorInfo = response.Headers.Contains("X-Sentry-Error")
+                    ? string.Join("\n", response.Headers.GetValues("X-Sentry-Error"))
+                    : "";
+
+                throw new SentryClientException(HttpStatusCode.BadRequest, errorInfo);
             }
             
             var responseMessage = JsonConvert.DeserializeObject<SentrySuccessResponse>(await response.Content.ReadAsStringAsync());


### PR DESCRIPTION
The SentryClient checks if the X-Sentry-Error header exists on error responses from the API before accessing them.

This fixes issue #2 .